### PR TITLE
Microsoft Orleans packages updated to the version v2.4.1. (#12)

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,4 @@
+mode: ContinuousDeployment
+branches: {}
+ignore:
+  sha: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,13 @@ steps:
   inputs:
     feedsToUse: config
 # ...
+# Version with GitVersion
+- task: gittools.gitversion.gitversion-task.GitVersion@4
+  displayName: GitVersion
+  inputs:
+    updateAssemblyInfo: true
+    preferBundledVersion: false
+# ...
 # Build Solution
 - task: VSBuild@1
   displayName: 'Build solution Orleans.Security.Build.sln'
@@ -55,6 +62,8 @@ steps:
   displayName: 'NuGet pack Orleans.Security.Build.sln'
   inputs:
     command: pack
+    versioningScheme: byEnvVar
+    versionEnvVar: GitVersion.SemVer
     packagesToPack: Orleans.Security.Build.sln
 # ...
 # Push NuGet packs to feed
@@ -62,4 +71,4 @@ steps:
   displayName: 'NuGet push'
   inputs:
     command: push
-    publishVstsFeed: '/ebb2809e-41ed-479a-9185-3bfe72acbe84'
+    publishVstsFeed: '/c98d9aaf-ce19-4121-8b3d-4209a8f3ee5e'

--- a/src/Orleans.Security.Client/AssemblyInfo.cs
+++ b/src/Orleans.Security.Client/AssemblyInfo.cs
@@ -2,3 +2,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Orleans.Security.IntegrationTests")]
+
+[assembly: AssemblyVersion("2.4.1.0")]
+[assembly: AssemblyFileVersion("2.4.1.0")]
+[assembly: AssemblyInformationalVersion("2.4.1-upgrade-to-ms-orleans.7+Branch.feature/upgrade-to-ms-orleans-v2.4.1.Sha.28005336790aafa81b1e204a62018caf545e3a1c")]

--- a/src/Orleans.Security.Client/Orleans.Security.Client.csproj
+++ b/src/Orleans.Security.Client/Orleans.Security.Client.csproj
@@ -5,13 +5,14 @@
     <Authors>AsyncHub</Authors>
     <PackageProjectUrl>https://orlsec.asynchub.org/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Async-Hub/Orleans.Security</RepositoryUrl>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel" Version="3.10.10" />
+    <PackageReference Include="IdentityModel" Version="4.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.3.5" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.Security.Clustering/AssemblyInfo.cs
+++ b/src/Orleans.Security.Clustering/AssemblyInfo.cs
@@ -2,3 +2,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Orleans.Security.IntegrationTests")]
+
+[assembly: AssemblyVersion("2.4.1.0")]
+[assembly: AssemblyFileVersion("2.4.1.0")]
+[assembly: AssemblyInformationalVersion("2.4.1-upgrade-to-ms-orleans.7+Branch.feature/upgrade-to-ms-orleans-v2.4.1.Sha.28005336790aafa81b1e204a62018caf545e3a1c")]

--- a/src/Orleans.Security.Clustering/Orleans.Security.Clustering.csproj
+++ b/src/Orleans.Security.Clustering/Orleans.Security.Clustering.csproj
@@ -6,12 +6,13 @@
     <Company>AsyncHub</Company>
     <PackageProjectUrl>https://orlsec.asynchub.org/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Async-Hub/Orleans.Security</RepositoryUrl>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JWT" Version="5.2.0" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.3.5" />
+    <PackageReference Include="JWT" Version="5.2.3" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Orleans.Security/AssemblyInfo.cs
+++ b/src/Orleans.Security/AssemblyInfo.cs
@@ -5,3 +5,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Orleans.Security.Clustering")]
 [assembly: InternalsVisibleTo("Orleans.Security.IntegrationTests.Functional")]
 [assembly: InternalsVisibleTo("Orleans.Security.IntegrationTests.TokenVerification")]
+
+[assembly: AssemblyVersion("2.4.1.0")]
+[assembly: AssemblyFileVersion("2.4.1.0")]
+[assembly: AssemblyInformationalVersion("2.4.1-upgrade-to-ms-orleans.7+Branch.feature/upgrade-to-ms-orleans-v2.4.1.Sha.28005336790aafa81b1e204a62018caf545e3a1c")]

--- a/src/Orleans.Security/Orleans.Security.csproj
+++ b/src/Orleans.Security/Orleans.Security.csproj
@@ -6,18 +6,19 @@
     <Company>AsyncHub</Company>
     <PackageProjectUrl>https://orlsec.asynchub.org/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Async-Hub/Orleans.Security</RepositoryUrl>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="3.10.10" />
-    <PackageReference Include="JWT" Version="5.2.0" />
+    <PackageReference Include="JWT" Version="5.2.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.4.0" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.3.5" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.5.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.4.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Orleans.Security.IntegrationTests.Functional/Orleans.Security.IntegrationTests.Functional.fsproj
+++ b/test/Orleans.Security.IntegrationTests.Functional/Orleans.Security.IntegrationTests.Functional.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -11,8 +11,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
+    <PackageReference Update="FSharp.Core" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Orleans.Security.IntegrationTests/Orleans.Security.IntegrationTests.csproj
+++ b/test/Orleans.Security.IntegrationTests/Orleans.Security.IntegrationTests.csproj
@@ -5,18 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="2.3.5" />
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.3.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.3.5" />
-    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.3.5" />
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.4.1" />
+    <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="2.4.1" />
     <PackageReference Include="Moq" Version="4.12.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Microsoft Orleans packages updated to the version v2.4.1.

* Azure DevOps feed id was updated.

* Added GitVersion into Azure DevOps pipeline.

* The following "#arguments: '--logger:trx'" excluded from Run Tests task in Azure DevOps pipline.

* Modified the order of "Version with GitVersion" task in Azure DevOps pipeline config file.

* "<GenerateAssemblyInfo>false</GenerateAssemblyInfo>" added into Orleans.Security project.

* "<GenerateAssemblyInfo>false</GenerateAssemblyInfo>" added into Orleans.Security.Client/Orleans.Security.Clustering project.

* Some AssemblyVersion attributes added into scr projects.

* Azure DevOps build pipline configuration updated. Task "Version with GitVersion" moved to the top.

* Added command argument "arguments: '/p:Version=$(Build.BuildNumber)'" into task "NuGet pack Orleans.Security.Build.sln" in azure-pipelines.yml.

* Changed version scheme for task "NuGet pack Orleans.Security.Build.sln" in azure-pipelines.yml.